### PR TITLE
Coral Manipulator no longer moves after disabled

### DIFF
--- a/simgui-ds.json
+++ b/simgui-ds.json
@@ -1,4 +1,9 @@
 {
+  "Keyboard 0 Settings": {
+    "window": {
+      "visible": true
+    }
+  },
   "keyboardJoysticks": [
     {
       "axisConfig": [
@@ -21,12 +26,17 @@
         }
       ],
       "axisCount": 5,
-      "buttonCount": 4,
+      "buttonCount": 9,
       "buttonKeys": [
-        90,
-        88,
-        67,
-        86
+        49,
+        50,
+        51,
+        52,
+        53,
+        54,
+        55,
+        56,
+        57
       ],
       "povConfig": [
         {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -54,7 +54,11 @@ public class Robot extends TimedRobot {
 
     /** This method is called once each time the robot enters Disabled mode. */
     @Override
-    public void disabledInit() {}
+    public void disabledInit() {
+        if (autonomousCommand != null) {
+            autonomousCommand.cancel();
+        }
+    }
 
     @Override
     public void disabledPeriodic() {}
@@ -65,7 +69,6 @@ public class Robot extends TimedRobot {
     @Override
     public void autonomousInit() {
         autonomousCommand = robotContainer.getAutonomousCommand();
-
         if (autonomousCommand != null) {
             autonomousCommand.schedule();
         }
@@ -77,9 +80,12 @@ public class Robot extends TimedRobot {
 
     @Override
     public void teleopInit() {
-        if (autonomousCommand != null) {
-            autonomousCommand.cancel();
-        }
+        CommandScheduler.getInstance().cancelAll();
+        robotContainer
+                .coralManipulator
+                .transitionTo(CoralManipulatorState.IDLE)
+                .ignoringDisable(true)
+                .schedule();
     }
 
     /** This method is called periodically during operator control. */
@@ -98,6 +104,11 @@ public class Robot extends TimedRobot {
     @Override
     public void testInit() {
         CommandScheduler.getInstance().cancelAll();
+        robotContainer
+                .coralManipulator
+                .transitionTo(CoralManipulatorState.IDLE)
+                .ignoringDisable(true)
+                .schedule();
     }
 
     /** This method is called periodically during test mode. */
@@ -106,7 +117,14 @@ public class Robot extends TimedRobot {
 
     /** This method is called once when the robot is first started up. */
     @Override
-    public void simulationInit() {}
+    public void simulationInit() {
+        CommandScheduler.getInstance().cancelAll();
+        robotContainer
+                .coralManipulator
+                .transitionTo(CoralManipulatorState.IDLE)
+                .ignoringDisable(true)
+                .schedule();
+    }
 
     /** This method is called periodically whilst in simulation. */
     @Override

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -86,8 +86,12 @@ public class RobotContainer {
                                                 -primaryXboxController.getRightX()
                                                         * TunerConstants.MaFxAngularRate)));
         primaryXboxController.start().onTrue(drivetrain.runOnce(drivetrain::seedFieldCentric));
-        primaryXboxController.y().onTrue(coralManipulator.transitionTo(CoralManipulatorState.L1));
-        primaryXboxController.b().onTrue(coralManipulator.transitionTo(CoralManipulatorState.L2));
+        primaryXboxController
+                .y()
+                .onTrue(coralManipulator.transitionTo(CoralManipulatorState.L1));
+        primaryXboxController
+                .b()
+                .onTrue(coralManipulator.transitionTo(CoralManipulatorState.L2));
         primaryXboxController.a().onTrue(coralManipulator.transitionTo(CoralManipulatorState.L3));
         primaryXboxController.x().onTrue(coralManipulator.transitionTo(CoralManipulatorState.L4));
         primaryXboxController

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -86,12 +86,8 @@ public class RobotContainer {
                                                 -primaryXboxController.getRightX()
                                                         * TunerConstants.MaFxAngularRate)));
         primaryXboxController.start().onTrue(drivetrain.runOnce(drivetrain::seedFieldCentric));
-        primaryXboxController
-                .y()
-                .onTrue(coralManipulator.transitionTo(CoralManipulatorState.L1));
-        primaryXboxController
-                .b()
-                .onTrue(coralManipulator.transitionTo(CoralManipulatorState.L2));
+        primaryXboxController.y().onTrue(coralManipulator.transitionTo(CoralManipulatorState.L1));
+        primaryXboxController.b().onTrue(coralManipulator.transitionTo(CoralManipulatorState.L2));
         primaryXboxController.a().onTrue(coralManipulator.transitionTo(CoralManipulatorState.L3));
         primaryXboxController.x().onTrue(coralManipulator.transitionTo(CoralManipulatorState.L4));
         primaryXboxController


### PR DESCRIPTION
# Pull Request Template

## Type of Change
<!-- Please check the one(s) that apply: -->
- [X] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation Update
- [ ] Other (please specify):

## Subsystem(s) Modified
<!-- List all robot subsystems that are affected by this change -->
- Robot

## Description of Changes
<!-- Provide a clear and concise description of the changes made -->
Coral manipulator no longer moves after disabled and enabled

## Additional Context
<!-- Add any other context about the changes here -->

## Checklist

- [X] Code follows team's coding standards
- [X] Comments added/updated where needed
- [X] Changes have been tested in simulation (if applicable)
- [X] Changes have been tested on the robot (if applicable)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
